### PR TITLE
`ldt::Pencil::name`について、`std::string`から`char []`に変更

### DIFF
--- a/libdermtiff/include/libdermtiff/dermtiff/pencil.hpp
+++ b/libdermtiff/include/libdermtiff/dermtiff/pencil.hpp
@@ -6,15 +6,25 @@
 
 namespace ldt {
     struct Pencil {
-        std::string name = "";
+        static const uint8_t MaxNameLength = 64;
+
+        char name[MaxNameLength + 1] = "\0";
         uint8_t r = 0, g = 0, b = 0, a = 255;
 
+        Pencil() = default;
+
+        Pencil(std::string_view _name);
+
+        Pencil(std::string_view _name, uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a = 255);
+
         static std::optional<Pencil> Parse(const std::string& str);
+
+        bool setName(std::string_view _name);
 
         std::optional<std::string> toString() const;
 
         bool operator==(const Pencil& other) const noexcept {
-            return name == other.name && r == other.r && g == other.g && b == other.b;
+            return strcmp(name, other.name) == 0 && r == other.r && g == other.g && b == other.b;
         }
 
         bool operator!=(const Pencil& other) const noexcept {

--- a/libdermtiff/include/libdermtiff/dermtiff/pencil.hpp
+++ b/libdermtiff/include/libdermtiff/dermtiff/pencil.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <string>
 

--- a/libdermtiff/src/pencil.cpp
+++ b/libdermtiff/src/pencil.cpp
@@ -31,6 +31,18 @@ namespace ldt {
         }
     }
 
+    Pencil::Pencil(std::string_view _name) {
+        setName(_name);
+    }
+
+    Pencil::Pencil(std::string_view _name, uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) {
+        setName(_name);
+        r = _r;
+        g = _g;
+        b = _b;
+        a = _a;
+    }
+
     std::optional<Pencil> Pencil::Parse(const std::string& str) {
         Pencil pencil;
 
@@ -40,12 +52,14 @@ namespace ldt {
             return std::nullopt;
         }
 
-        pencil.name = str.substr(0, index);
-        _internal::trimSpaces(pencil.name);
-        if (pencil.name.empty()) {
+        std::string pencilName = str.substr(0, index);
+        _internal::trimSpaces(pencilName);
+        if (pencilName.empty()) {
             msg::Output(msg::Type::Error, "Pencil::Parse", "Empty pencil name");
             return std::nullopt;
         }
+
+        strcpy(pencil.name, pencilName.c_str());
 
         try {
             auto colorString = str.substr(index + 1, str.length() - index);
@@ -81,8 +95,22 @@ namespace ldt {
         }
     }
 
+    bool Pencil::setName(std::string_view _name) {
+        const bool isValidLength = _name.length() <= MaxNameLength;
+
+        if (isValidLength) {
+            strcpy(name, _name.data());
+        } else {
+            const auto str = std::string(_name.substr(0, MaxNameLength)) + '\0';
+            strcpy(name, str.data());
+            msg::Output(msg::Type::Warning, "Pencil::setName", "Name length exceeds the limit");
+        }
+
+        return isValidLength;
+    }
+
     std::optional<std::string> Pencil::toString() const {
-        if (name.empty()) {
+        if (std::string(name).empty()) {
             msg::Output(msg::Type::Error, "Pencil::toString", "Empty pencil name");
             return std::nullopt;
         }

--- a/test/pencilToString.cpp
+++ b/test/pencilToString.cpp
@@ -5,18 +5,28 @@
 int main() {
     {
         ldt::Pencil pencil;
-        pencil.name = "";
+        pencil.setName("");
         assert(!pencil.toString().has_value());
     }
 
     {
         ldt::Pencil pencil;
-        pencil.name = "pencil";
-        pencil.r    = 255;
-        pencil.g    = 255;
-        pencil.b    = 255;
-        pencil.a    = 255;
+        pencil.setName("pencil");
+        pencil.r = 255;
+        pencil.g = 255;
+        pencil.b = 255;
+        pencil.a = 255;
         assert(pencil.toString() == "pencil/(255,255,255,255)");
+    }
+
+    // Exceeds limit
+    {
+        const std::string limit  = std::string(ldt::Pencil::MaxNameLength, 'a');
+        const std::string exceed = limit + "b";
+
+        ldt::Pencil pencil;
+        pencil.setName(exceed);
+        assert(std::string(pencil.name) == limit);
     }
 
     return 0;


### PR DESCRIPTION
fix #15 