### PR TITLE
`io::WriteTIFF`について、`rasters` `pencils`の引数を`const`に

### DIFF
--- a/libdermtiff/include/libdermtiff/dermtiff/io.hpp
+++ b/libdermtiff/include/libdermtiff/dermtiff/io.hpp
@@ -50,6 +50,6 @@ namespace ldt::io {
                    uint16_t layerCount,
                    uint32_t width,
                    uint32_t height,
-                   uint32_t* rasters[],
-                   Pencil pencils[]);
+                   uint32_t** rasters,
+                   Pencil* pencils);
 }

--- a/libdermtiff/include/libdermtiff/dermtiff/io.hpp
+++ b/libdermtiff/include/libdermtiff/dermtiff/io.hpp
@@ -50,6 +50,6 @@ namespace ldt::io {
                    uint16_t layerCount,
                    uint32_t width,
                    uint32_t height,
-                   uint32_t** rasters,
+                   uint32_t* const* const rasters,
                    const Pencil* const pencils);
 }

--- a/libdermtiff/include/libdermtiff/dermtiff/io.hpp
+++ b/libdermtiff/include/libdermtiff/dermtiff/io.hpp
@@ -51,5 +51,5 @@ namespace ldt::io {
                    uint32_t width,
                    uint32_t height,
                    uint32_t** rasters,
-                   Pencil* pencils);
+                   const Pencil* const pencils);
 }

--- a/libdermtiff/src/io.cpp
+++ b/libdermtiff/src/io.cpp
@@ -95,8 +95,8 @@ namespace ldt::io {
                    uint16_t layerCount,
                    uint32_t width,
                    uint32_t height,
-                   uint32_t* rasters[],
-                   Pencil pencils[]) {
+                   uint32_t** rasters,
+                   Pencil* pencils) {
         const uint16_t pageCount = layerCount + 1;
 
         // check parameters

--- a/libdermtiff/src/io.cpp
+++ b/libdermtiff/src/io.cpp
@@ -32,11 +32,13 @@ namespace ldt::io {
                 return result;
             }
 
-            bool WriteImage(TIFF* const tiff, uint32_t width, uint32_t height, uint32_t* raster) {
+            bool WriteImage(TIFF* const tiff, uint32_t width, uint32_t height, uint32_t* const raster) {
                 for (uint32_t y = 0; y < height; y++) {
                     const auto pos = y * width;
                     // raster + pos is the pointer of the image[y][0]
-                    if (TIFFWriteScanline(tiff, raster + pos, y) != 1) {
+                    // Since libtiff interface does not support const, so use const_cast to remove const
+                    // Writing process only reads the value, there is no change
+                    if (TIFFWriteScanline(tiff, const_cast<uint32_t* const>(raster) + pos, y) != 1) {
                         msg::Output(msg::Type::Error, "io::WriteImage", "Could not write the image");
                         return false;
                     }
@@ -95,7 +97,7 @@ namespace ldt::io {
                    uint16_t layerCount,
                    uint32_t width,
                    uint32_t height,
-                   uint32_t** rasters,
+                   uint32_t* const* const rasters,
                    const Pencil* const pencils) {
         const uint16_t pageCount = layerCount + 1;
 

--- a/libdermtiff/src/io.cpp
+++ b/libdermtiff/src/io.cpp
@@ -96,7 +96,7 @@ namespace ldt::io {
                    uint32_t width,
                    uint32_t height,
                    uint32_t** rasters,
-                   Pencil* pencils) {
+                   const Pencil* const pencils) {
         const uint16_t pageCount = layerCount + 1;
 
         // check parameters


### PR DESCRIPTION
close #23 