### PR TITLE
`io::WriteTIFF()`において、`rasters`の型を `const uint32_t* const* const`に変更

### DIFF
--- a/libdermtiff/include/libdermtiff/dermtiff/io.hpp
+++ b/libdermtiff/include/libdermtiff/dermtiff/io.hpp
@@ -50,6 +50,6 @@ namespace ldt::io {
                    uint16_t layerCount,
                    uint32_t width,
                    uint32_t height,
-                   uint32_t* const* const rasters,
+                   const uint32_t* const* const rasters,
                    const Pencil* const pencils);
 }

--- a/libdermtiff/src/io.cpp
+++ b/libdermtiff/src/io.cpp
@@ -32,7 +32,7 @@ namespace ldt::io {
                 return result;
             }
 
-            bool WriteImage(TIFF* const tiff, uint32_t width, uint32_t height, uint32_t* const raster) {
+            bool WriteImage(TIFF* const tiff, uint32_t width, uint32_t height, const uint32_t* const raster) {
                 for (uint32_t y = 0; y < height; y++) {
                     const auto pos = y * width;
                     // raster + pos is the pointer of the image[y][0]
@@ -97,7 +97,7 @@ namespace ldt::io {
                    uint16_t layerCount,
                    uint32_t width,
                    uint32_t height,
-                   uint32_t* const* const rasters,
+                   const uint32_t* const* const rasters,
                    const Pencil* const pencils) {
         const uint16_t pageCount = layerCount + 1;
 


### PR DESCRIPTION
close #28 